### PR TITLE
Fix adding extra .file extension on FileSystem storage

### DIFF
--- a/lib/shrine/plugins/tus.rb
+++ b/lib/shrine/plugins/tus.rb
@@ -20,7 +20,7 @@ class Shrine
           tus_uid = tus_url.split("/").last
 
           if defined?(Storage::FileSystem) && storage.is_a?(Storage::FileSystem)
-            "#{tus_uid}.file"
+            tus_uid.end_with?('.file') ? tus_uid : "#{tus_uid}.file"
           elsif defined?(Storage::Gridfs) && storage.is_a?(Storage::Gridfs)
             grid_info = storage.bucket.find(filename: tus_uid).limit(1).first
             grid_info[:_id].to_s

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -35,6 +35,17 @@ describe Shrine::Plugins::Tus do
       assert_equal "#{tus_uid}.file", attachment.id
       assert_equal "bar",             attachment.metadata["foo"]
     end
+
+    it "does not add extra .file to the end of storage id" do
+      tus_uid = SecureRandom.hex
+      data = {id: "http://tus-server.org/files/#{tus_uid}.file", storage: "cache", metadata: {"foo" => "bar"}}
+
+      @attacher.assign(data.to_json)
+      attachment = @attacher.get
+
+      assert_equal "#{tus_uid}.file", attachment.id
+      assert_equal "bar",             attachment.metadata["foo"]
+    end
   end
 
   describe "for Gridfs" do


### PR DESCRIPTION
I have encountered a problem and hopefully managed to fix: when `cached_attachment_data` plugin is used together with `tus` plugin, `tus` adds extra `.file` extension when it's already there after failed validation.